### PR TITLE
 Change idle_heartbeat_timeout default value from 30 to 10

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3536,7 +3536,7 @@ class ResponseFuture(object):
             pool = self.session._pools.get(self._current_host)
             if pool and not pool.is_shutdown:
                 with self._connection.lock:
-                    self._connection.request_ids.append(self._req_id)
+                    self._connection._request_ids.append(self._req_id)
 
                 pool.return_connection(self._connection)
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -798,7 +798,7 @@ class Cluster(object):
                  execution_profiles=None,
                  allow_beta_protocol_version=False,
                  timestamp_generator=None,
-                 idle_heartbeat_timeout=30,
+                 idle_heartbeat_timeout=10,
                  no_compact=False):
         """
         ``executor_threads`` defines the number of threads in a pool for handling asynchronous tasks such as

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -290,11 +290,11 @@ class Connection(object):
             # Don't fill the deque with 2**15 items right away. Start with some and add
             # more if needed.
             initial_size = min(300, self.max_in_flight)
-            self.request_ids = deque(range(initial_size))
+            self._request_ids = deque(range(initial_size))
             self.highest_request_id = initial_size - 1
         else:
             self.max_request_id = min(self.max_in_flight, (2 ** 7) - 1)
-            self.request_ids = deque(range(self.max_request_id + 1))
+            self._request_ids = deque(range(self.max_request_id + 1))
             self.highest_request_id = self.max_request_id
 
         self.lock = RLock()
@@ -442,7 +442,7 @@ class Connection(object):
         This must be called while self.lock is held.
         """
         try:
-            return self.request_ids.popleft()
+            return self._request_ids.popleft()
         except IndexError:
             new_request_id = self.highest_request_id + 1
             # in_flight checks should guarantee this
@@ -603,7 +603,7 @@ class Connection(object):
                 return
 
             with self.lock:
-                self.request_ids.append(stream_id)
+                self._request_ids.append(stream_id)
 
         try:
             response = decoder(header.version, self.user_type_map, stream_id,

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -747,7 +747,7 @@ class ClusterTests(unittest.TestCase):
                 # make sure none are idle (should have startup messages
                 self.assertFalse(c.is_idle)
                 with c.lock:
-                    connection_request_ids[id(c)] = deque(c.request_ids)  # copy of request ids
+                    connection_request_ids[id(c)] = deque(c._request_ids)  # copy of request ids
 
         # let two heatbeat intervals pass (first one had startup messages in it)
         time.sleep(2 * interval + interval/2)
@@ -759,7 +759,7 @@ class ClusterTests(unittest.TestCase):
             expected_ids = connection_request_ids[id(c)]
             expected_ids.rotate(-1)
             with c.lock:
-                self.assertListEqual(list(c.request_ids), list(expected_ids))
+                self.assertListEqual(list(c._request_ids), list(expected_ids))
 
         # assert idle status
         self.assertTrue(all(c.is_idle for c in connections))

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -43,7 +43,7 @@ def assert_quiescent_pool_state(test_case, cluster, wait=None):
     for holder in cluster.get_connection_holders():
         for connection in holder.get_connections():
             # all ids are unique
-            req_ids = connection.request_ids
+            req_ids = connection._request_ids
             test_case.assertEqual(len(req_ids), len(set(req_ids)))
             test_case.assertEqual(connection.highest_request_id, len(req_ids) - 1)
             test_case.assertEqual(connection.highest_request_id, max(req_ids))


### PR DESCRIPTION
solution for [#928](https://datastax-oss.atlassian.net/projects/PYTHON/issues/PYTHON-928). idle_heatbet_timeout default to be 10 from 30.